### PR TITLE
Fix calendar position when scrolled

### DIFF
--- a/src/components/DatetimePicker/datetime-picker.scss
+++ b/src/components/DatetimePicker/datetime-picker.scss
@@ -3,7 +3,8 @@
 .date-time-picker {
   text-align: left;
   color: $secondary-font-color;
-  padding: 300px 0;
+  margin: 300px 0;
+  position: relative;
 
   .date-time-input {
     height: 40px;

--- a/src/components/DatetimePicker/index.tsx
+++ b/src/components/DatetimePicker/index.tsx
@@ -149,16 +149,16 @@ const DatetimePicker = forwardRef<DatetimePickerRef, DatetimePickerProps>(functi
     const newMenuPosition = { ...menuPosition };
     // Check if the menu overflows to the right
     if (inputRect.left + menuRect.width + buffer > innerWidth) {
-      newMenuPosition.left = inputRect.left + inputRect.width - menuRect.width;
+      newMenuPosition.left = inputRect.width - menuRect.width;
     } else {
-      newMenuPosition.left = inputRect.left;
+      newMenuPosition.left = 0;
     }
 
     // Check if the menu overflows to the bottom
     if (inputRect.top + inputRect.height + menuRect.height + buffer > innerHeight) {
-      newMenuPosition.top = inputRect.top - menuRect.height - buffer;
+      newMenuPosition.top = -menuRect.height - buffer;
     } else {
-      newMenuPosition.top = inputRect.top + inputRect.height + buffer;
+      newMenuPosition.top = inputRect.height + buffer;
     }
 
     setAdjustedPosition({ ...newMenuPosition, opacity: 1 });


### PR DESCRIPTION
when you scroll, the calendar does not moved, so there are cases, like in the video, where it is not possible to see the days